### PR TITLE
Fix background of eglot mode-line in inactive windows

### DIFF
--- a/simplicity-theme.el
+++ b/simplicity-theme.el
@@ -506,10 +506,8 @@ defining them in this alist."
      ((t (:inherit git-gutter:deleted))))
 ;;;;; eglot
   `(eglot-mode-line
-    ((t (:inherit font-lock-constant-face
-         :weight bold
-         :foreground ,simplicity-background
-         :background ,simplicity-grey-1))))))
+    ((t (:foreground ,simplicity-background
+         :weight bold))))))
 
 
 ;;;###autoload


### PR DESCRIPTION
I made a mistake in my last PR, the style values were grabbed from an active window. As written, they also apply to inactive windows. Below are screenshots of modelines for two files, with the left active and the right inactive:  

![before_eglot_fix](https://user-images.githubusercontent.com/9307830/196022533-ab2abc00-bd06-4ded-ac54-0870d94d9e1b.png)

Fixed by removing improper styles and only specifying font color/weight for Eglot's modeline text:

![after_eglot_fix](https://user-images.githubusercontent.com/9307830/196022682-23b9eff7-8fb7-4872-9d0d-1cd7a5b89418.png)

